### PR TITLE
Include tampermonkey links to browser marketplaces in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ This userscript adds quality of life updates to Jira interface for Customer Supp
 
 ## Installation
 
-1. Install a userscript manager like [Tampermonkey](https://www.tampermonkey.net/).
+1. Install a userscript manager like [Tampermonkey](https://www.tampermonkey.net/):
+- chrome: https://chromewebstore.google.com/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en
+- firefox: https://addons.mozilla.org/en-US/firefox/addon/tampermonkey/
 2. Create a new userscript and paste the code from `Jira for CSEs.user.js`.  
 3. Save and reload Jira pages.
-
-
-


### PR DESCRIPTION
The tampermonkey site is riddled with ads and suspicious looking download installs for the extension itself.  Updating the README.md to include links to Chrome and Firefox marketplaces for installs.