### PR TITLE
Improve the error message when there is no Organiztion asset

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -250,7 +250,7 @@
         const field = data.fields.customfield_12557?.[0];
 
         if (!field) {
-            throw new Error('customfield_12557 missing or empty on ticket.');
+            throw new Error('"Organization Asset" missing or empty on ticket.');
         }
 
         // Return only necessary IDs


### PR DESCRIPTION
Hey there!
Just a minor change.

Improve the error message when there is no `Organization` asset and the Customer Portal link cannot be created

Current:
<img width="360" height="183" alt="image" src="https://github.com/user-attachments/assets/10c6588d-3dd3-4bc0-8958-e23e6d51ecca" />

New:
<img width="479" height="200" alt="image" src="https://github.com/user-attachments/assets/03bd634f-ad34-404c-a35f-6779cbafdf81" />
