### PR TITLE
[Bug fix] Custom fields were added within the 'Heat Score' tab when this tab was opened by default

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -3,7 +3,7 @@
 // @author       Ally, Rita, Dmcisneros
 // @icon         https://www.liferay.com/o/classic-theme/images/favicon.ico
 // @namespace    https://liferay.atlassian.net/
-// @version      3.22
+// @version      3.23
 // @description  Jira statuses + Patcher, Account tickets and CP Link field + Internal Note highlight + Auto Expand CCC Info + colorize solution proposed + Internal Request Warning + Large File Attachment section
 // @match        https://liferay.atlassian.net/*
 // @match        https://liferay-sandbox-424.atlassian.net/*

--- a/userscript.js
+++ b/userscript.js
@@ -171,52 +171,18 @@
     }
 
     function createJiraFilterLinkField() {
-        // Select the original field wrapper to clone its structure
-        const originalField = document.querySelector('[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]');
-        if (!originalField) return;
-
-        // We insert the new field after the original Patcher Link field
-        const referenceField = document.querySelector('.patcher-link-field');
-        if (!referenceField) return; // Ensure the Patcher field exists first
-
-        // Prevent duplicates
-        if (document.querySelector('.jira-filter-link-field')) return;
+        const ticketType = getTicketType();
+        if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
 
         const accountCode = getAccountCode();
-        const clone = originalField.cloneNode(true);
 
-        // Cleanup: Remove the duplicated "Assign to Me" button
-        clone.querySelector('[data-testid="issue-view-layout-assignee-field.ui.assign-to-me"]')?.remove();
-
-        // UNIQUE CLASS AND HEADING
-        clone.classList.add('jira-filter-link-field');
-        const span = clone.querySelector('span');
-        if (span) span.textContent = 'Account Filter'; // Descriptive Title
-
-        const contentContainer = clone.querySelector('[data-testid="issue-field-inline-edit-read-view-container.ui.container"]');
-        if (contentContainer) contentContainer.innerHTML = '';
-
-        // LINK CREATION
-        const link = document.createElement('a');
-        if (accountCode) {
-            // Use the new function to generate the Jira filter URL
-            link.href = getJiraFilterHref(accountCode);
-            link.target = '_blank';
-            link.textContent = accountCode;
-        } else {
-            // Handle case where Account Code is missing
-            link.textContent = 'Account Code Missing';
-            link.style.color = '#999';
+        const callbackFn = async () => {
+            const url = getJiraFilterHref(accountCode);
+            return { url, name: accountCode };
         }
+        const newField = { heading: 'Account Filter', class: 'jira-filter-link-field' }
 
-        // Styles
-        link.style.display = 'block';
-        link.style.marginTop = '5px';
-        link.style.textDecoration = 'underline';
-        contentContainer?.appendChild(link);
-
-        // Insert the new field after the Patcher Link field
-        referenceField.parentNode.insertBefore(clone, referenceField.nextSibling);
+        createPanelFieldLink({ newField, callbackFn })
     }
 
      /*********** ADD COLOR TO PROPOSED SOLUTION ***********/
@@ -260,41 +226,15 @@
         const ticketType = getTicketType();
         if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
 
-        const originalField = document.querySelector('[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]');
-        if (!originalField) return;
-        if (document.querySelector('.patcher-link-field')) return;
-
         const accountCode = getAccountCode();
-        const clone = originalField.cloneNode(true);
-        // Remove the Assign to Me, which is duplicated
-        const assignToMe = clone.querySelector('[data-testid="issue-view-layout-assignee-field.ui.assign-to-me"]');
-        if (assignToMe) {
-            assignToMe.remove();
+
+        const callbackFn = async () => {
+            const url = getPatcherPortalAccountsHREF('', { accountEntryCode: accountCode });
+            return { url, name: accountCode };
         }
-        clone.classList.add('patcher-link-field');
+        const newField = { heading: 'Patcher Portal', class: 'patcher-link-field' }
 
-        const span = clone.querySelector('span');
-        if (span) span.textContent = 'Patcher Link';
-
-        const contentContainer = clone.querySelector('[data-testid="issue-field-inline-edit-read-view-container.ui.container"]');
-        if (contentContainer) contentContainer.innerHTML = '';
-
-        const link = document.createElement('a');
-        if (accountCode) {
-            link.href = getPatcherPortalAccountsHREF('', { accountEntryCode: accountCode });
-            link.target = '_blank';
-            link.textContent = accountCode;
-        } else {
-            link.textContent = 'Account Code Missing';
-            link.style.color = '#999';
-        }
-
-        link.style.display = 'block';
-        link.style.marginTop = '5px';
-        link.style.textDecoration = 'underline';
-        contentContainer && contentContainer.appendChild(link);
-
-        originalField.parentNode.insertBefore(clone, originalField.nextSibling);
+        createPanelFieldLink({ newField, callbackFn })
     }
 
     /*********** CUSTOMER PORTAL LINK FIELD ***********/
@@ -398,65 +338,23 @@
 
 
     // 6. Main function to create and insert the field (handles UI updates only)
-    async function createCustomerPortalField() {
+    function createCustomerPortalField() {
         const ticketType = getTicketType();
         if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
-
-        const originalField = document.querySelector('[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]');
-        if (!originalField || document.querySelector('.customer-portal-link-field')) return;
 
         const issueKey = getIssueKey();
         if (!issueKey) return;
 
-        // --- UI Setup ---
-        const clone = originalField.cloneNode(true);
-        // Remove duplicated "Assign to Me"
-        clone.querySelector('[data-testid="issue-view-layout-assignee-field.ui.assign-to-me"]')?.remove();
-        clone.classList.add('customer-portal-link-field');
-
-        // Update field heading
-        const span = clone.querySelector('span');
-        if (span) span.textContent = 'Customer Portal';
-
-        // Get content container
-        const contentContainer = clone.querySelector('[data-testid="issue-field-inline-edit-read-view-container.ui.container"]');
-        if (contentContainer) contentContainer.innerHTML = '';
-
-        // Placeholder while fetching
-        const statusText = document.createElement('span');
-        statusText.textContent = 'Loading Portal Link...';
-        statusText.style.color = '#FFA500'; // Orange for loading
-        contentContainer?.appendChild(statusText);
-
-        // Insert the cloned field *before* fetching to provide immediate feedback
-        originalField.parentNode.insertBefore(clone, originalField.nextSibling);
-
-        // --- Data Fetch and Link Creation ---
-        try {
+        const callbackFn = async () => {
             const externalKey = await fetchCustomerPortalData(issueKey);
-            const url = getCustomerPortalHref(externalKey);
-
-            if (url && externalKey) {
-                contentContainer.innerHTML = ''; // Clear loading text
-                const link = document.createElement('a');
-                link.href = url;
-                link.target = '_blank';
-                link.textContent = externalKey;
-                link.style.cssText = 'display: block; margin-top: 5px; text-decoration: underline;';
-                contentContainer.appendChild(link);
-            } else {
-                statusText.textContent = 'Link Not Found (Missing Key)';
-                statusText.style.color = '#DC143C'; // Red for error
-            }
-        } catch (error) {
-            contentContainer.innerHTML = ''; // Clear loading text
-            const errorText = document.createElement('span');
-            errorText.textContent = `Error: ${error.message}`;
-            errorText.style.color = '#DC143C'; // Red for error
-            contentContainer.appendChild(errorText);
-            // Note: The original error is already logged by fetchCustomerPortalData
+            const url = externalKey ? `https://support.liferay.com/project/#/${externalKey}` : null;
+            return { url, name: externalKey };
         }
+        const newField = { heading: 'Customer Portal', class: 'customer-portal-link-field' }
+
+        createPanelFieldLink({ newField, callbackFn })
     }
+
 
     /*********** INTERNAL NOTE HIGHLIGHT ***********/
 
@@ -1092,7 +990,7 @@
             const url = externalKey ? `https://provisioning.liferay.com/group/guest/~/control_panel/manage?p_p_id=com_liferay_osb_provisioning_web_portlet_AccountsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_mvcRenderCommandName=%2Faccounts%2Fview_account&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_accountKey=${externalKey}` : null
             return { url, name: externalKey };
         }
-        const newField = { heading: 'Raysource Portal', class: 'raysource-portal-link-field' }
+        const newField = { heading: 'Raysource', class: 'raysource-portal-link-field' }
 
         createPanelFieldLink({ newField, callbackFn })
     }

--- a/userscript.js
+++ b/userscript.js
@@ -171,9 +171,6 @@
     }
 
     function createJiraFilterLinkField() {
-        const ticketType = getTicketType();
-        if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
-
         const accountCode = getAccountCode();
 
         const callbackFn = async () => {
@@ -223,9 +220,6 @@
     }
 
     function createPatcherField() {
-        const ticketType = getTicketType();
-        if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
-
         const accountCode = getAccountCode();
 
         const callbackFn = async () => {
@@ -339,9 +333,6 @@
 
     // 6. Main function to create and insert the field (handles UI updates only)
     function createCustomerPortalField() {
-        const ticketType = getTicketType();
-        if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
-
         const issueKey = getIssueKey();
         if (!issueKey) return;
 
@@ -979,9 +970,6 @@
     }
 
     function createProvisioningPortalFields() {
-        const ticketType = getTicketType();
-        if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
-
         const issueKey = getIssueKey();
         if (!issueKey) return;
 
@@ -995,15 +983,29 @@
         createPanelFieldLink({ newField, callbackFn })
     }
 
+    /**
+     * Initializes and renders custom fields within the Jira issue side panel if the ticket matches 
+     * allowed types ('LRHC' or 'LRFLS')
+     * 
+     * @returns {void}
+     */
+    function createCustomSidePanelFields() {
+        const ticketType = getTicketType();
+        if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
+
+        createCustomerPortalField();
+        createProvisioningPortalFields()
+        createPatcherField();
+        createJiraFilterLinkField();
+    }
+
+
     /*********** INITIAL RUN + OBSERVERS ***********/
     async function updateUI() {
         applyColors();
-        createPatcherField();
-        createJiraFilterLinkField();
+        createCustomSidePanelFields();
         highlightEditor();
-        createProvisioningPortalFields()
         checkInternalRequestWarning();
-        await createCustomerPortalField();
        // removeSignatureFromInternalNote();
         addFlameIconToHighPriority();
         expandCCCInfo();

--- a/userscript.js
+++ b/userscript.js
@@ -170,7 +170,7 @@
         return jiraFilterByAccountCode.replace('<CODE>', accountCode);
     }
 
-    function createJiraFilterLinkField() {
+    function createJiraFilterLinkField({ afterFieldClass = null }) {
         const accountCode = getAccountCode();
 
         const callbackFn = async () => {
@@ -179,7 +179,7 @@
         }
         const newField = { heading: 'Account Filter', class: 'jira-filter-link-field' }
 
-        createPanelFieldLink({ newField, callbackFn })
+        createPanelFieldLink({ newField, callbackFn, afterFieldClass })
     }
 
      /*********** ADD COLOR TO PROPOSED SOLUTION ***********/
@@ -219,7 +219,7 @@
         return accountDiv ? accountDiv.textContent.trim() : null;
     }
 
-    function createPatcherField() {
+    function createPatcherField({ afterFieldClass = null }) {
         const accountCode = getAccountCode();
 
         const callbackFn = async () => {
@@ -228,7 +228,7 @@
         }
         const newField = { heading: 'Patcher Portal', class: 'patcher-link-field' }
 
-        createPanelFieldLink({ newField, callbackFn })
+        createPanelFieldLink({ newField, callbackFn, afterFieldClass })
     }
 
     /*********** CUSTOMER PORTAL LINK FIELD ***********/
@@ -332,7 +332,7 @@
 
 
     // 6. Main function to create and insert the field (handles UI updates only)
-    function createCustomerPortalField() {
+    function createCustomerPortalField({ afterFieldClass = null }) {
         const issueKey = getIssueKey();
         if (!issueKey) return;
 
@@ -343,7 +343,7 @@
         }
         const newField = { heading: 'Customer Portal', class: 'customer-portal-link-field' }
 
-        createPanelFieldLink({ newField, callbackFn })
+        createPanelFieldLink({ newField, callbackFn, afterFieldClass })
     }
 
 
@@ -910,14 +910,20 @@
     * @param {string} config.newField.heading - The display heading of the field. Ex: `'Example Link'`
     * @param {string} config.newField.class - The CSS class applied to the field. Ex: `'example-link-field'`
     * @param {Function} config.callbackFn - Async callback executed to generate the link.
+    * @param {string} [options.afterFieldClass=null] - Optional. The CSS class of the field below which the new element should be placed. If omitted, it defaults to the "Assignee" field.
     *   Must resolve to an object with the following shape:
     *   `{ url: string, name: string }`
     *   Ex: `{ url: "https://www.liferay.com/", name: "Link" }`
     *
     * @returns {void}
     */
-    async function createPanelFieldLink({ newField, callbackFn }) {
-        const originalField = document.querySelector('[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]');
+    async function createPanelFieldLink({ newField, callbackFn, afterFieldClass = null }) {
+        // Determine the target selector: use the provided class or default to Jira's "Assignee" field selector
+        const targetSelector = afterFieldClass 
+            ? `.${afterFieldClass}` 
+            : '[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]';
+
+        const originalField = document.querySelector(targetSelector);
         if (!originalField || document.querySelector(`.${newField.class}`)) return;
 
         // --- UI Setup ---
@@ -969,7 +975,7 @@
         }
     }
 
-    function createProvisioningPortalFields() {
+    function createProvisioningPortalFields({ afterFieldClass = null }) {
         const issueKey = getIssueKey();
         if (!issueKey) return;
 
@@ -978,9 +984,9 @@
             const url = externalKey ? `https://provisioning.liferay.com/group/guest/~/control_panel/manage?p_p_id=com_liferay_osb_provisioning_web_portlet_AccountsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_mvcRenderCommandName=%2Faccounts%2Fview_account&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_accountKey=${externalKey}` : null
             return { url, name: externalKey };
         }
-        const newField = { heading: 'Raysource', class: 'raysource-portal-link-field' }
+        const newField = { heading: 'Raysource', class: 'raysource-link-field' }
 
-        createPanelFieldLink({ newField, callbackFn })
+        createPanelFieldLink({ newField, callbackFn, afterFieldClass })
     }
 
     /**
@@ -993,10 +999,10 @@
         const ticketType = getTicketType();
         if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
 
-        createCustomerPortalField();
-        createProvisioningPortalFields()
-        createPatcherField();
-        createJiraFilterLinkField();
+        createCustomerPortalField({});
+        createProvisioningPortalFields({ afterFieldClass: 'customer-portal-link-field' });
+        createPatcherField({ afterFieldClass: 'raysource-link-field' });
+        createJiraFilterLinkField({ afterFieldClass: 'patcher-link-field' });
     }
 
 

--- a/userscript.js
+++ b/userscript.js
@@ -172,7 +172,7 @@
 
     function createJiraFilterLinkField() {
         // Select the original field wrapper to clone its structure
-        const originalField = document.querySelector('[data-component-selector="jira-issue-field-heading-field-wrapper"]');
+        const originalField = document.querySelector('[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]');
         if (!originalField) return;
 
         // We insert the new field after the original Patcher Link field
@@ -260,7 +260,7 @@
         const ticketType = getTicketType();
         if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
 
-        const originalField = document.querySelector('[data-component-selector="jira-issue-field-heading-field-wrapper"]');
+        const originalField = document.querySelector('[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]');
         if (!originalField) return;
         if (document.querySelector('.patcher-link-field')) return;
 
@@ -402,7 +402,7 @@
         const ticketType = getTicketType();
         if (!['LRHC', 'LRFLS'].includes(ticketType)) return; // Only run for allowed types
 
-        const originalField = document.querySelector('[data-component-selector="jira-issue-field-heading-field-wrapper"]');
+        const originalField = document.querySelector('[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]');
         if (!originalField || document.querySelector('.customer-portal-link-field')) return;
 
         const issueKey = getIssueKey();
@@ -1028,7 +1028,7 @@
     * @returns {void}
     */
     async function createPanelFieldLink({ newField, callbackFn }) {
-        const originalField = document.querySelector('[data-component-selector="jira-issue-field-heading-field-wrapper"]');
+        const originalField = document.querySelector('[data-testid="issue.issue-view-layout.issue-view-assignee-field.assignee"]');
         if (!originalField || document.querySelector(`.${newField.class}`)) return;
 
         // --- UI Setup ---


### PR DESCRIPTION
You can easily reproduce the issue by changing to 'Heat Score' tab and reloading the page.

Current:
<img width="1636" height="510" alt="image" src="https://github.com/user-attachments/assets/e8914fba-7f53-4112-a26a-1410a5790a97" />

Fixed:
<img width="1626" height="476" alt="image" src="https://github.com/user-attachments/assets/37a9bee8-2ca0-48a7-af67-6792ec6fecc5" />

---

In addition to that, I've refactored the custom field creation to avoid boilerplate code by using `createPanelFieldLink` 