### PR TITLE
Add title to styled buttons

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -115,6 +115,7 @@
                 span.style.setProperty("color", "inherit", "important");
                 span.style.setProperty("font-size", "1em", "important");
                 span.style.setProperty("font-weight", "inherit", "important");
+                el.title=rawText;
             });
         });
     }

--- a/userscript.js
+++ b/userscript.js
@@ -3,7 +3,7 @@
 // @author       Ally, Rita, Dmcisneros
 // @icon         https://www.liferay.com/o/classic-theme/images/favicon.ico
 // @namespace    https://liferay.atlassian.net/
-// @version      3.25
+// @version      3.26
 // @description  Jira statuses + Patcher, Account tickets and CP Link field + Internal Note highlight + Auto Expand CCC Info + colorize solution proposed + Internal Request Warning + Large File Attachment section
 // @match        https://liferay.atlassian.net/*
 // @match        https://liferay-sandbox-424.atlassian.net/*


### PR DESCRIPTION
This change adds a title attribute to show the full word as a tooltip when it gets cut off
<img width="287" height="110" alt="image" src="https://github.com/user-attachments/assets/8f09d18e-c00e-47fe-adc8-918e48f3c36b" />
